### PR TITLE
Huebsch audio fixes

### DIFF
--- a/lib/__tests__/formatCredits.test.js
+++ b/lib/__tests__/formatCredits.test.js
@@ -5,7 +5,7 @@ describe('format credits', () => {
     const input = 'Von Markus Schärli, 25.09.2024'
     const output = addTtsNotice(input)
     expect(output).toEqual(
-      'Sie hören einen automatisch vorgelesenen Beitrag von Markus Schärli',
+      'Sie hören einen automatisch vorgelesenen Beitrag von Markus Schärli.',
     )
   })
 
@@ -14,7 +14,7 @@ describe('format credits', () => {
       'Von Lesha Berezovskiy (Text und Bilder) und Annette Keller (Übersetzung), 18.09.2024'
     const output = addTtsNotice(input)
     expect(output).toEqual(
-      'Sie hören einen automatisch vorgelesenen Beitrag von Lesha Berezovskiy und Annette Keller',
+      'Sie hören einen automatisch vorgelesenen Beitrag von Lesha Berezovskiy und Annette Keller.',
     )
   })
 
@@ -23,7 +23,7 @@ describe('format credits', () => {
       'Von Philipp Albrecht, Timo Kollbrunner (Text) und Lina Müller (Illustration), 23.09.2024'
     const output = addTtsNotice(input)
     expect(output).toEqual(
-      'Sie hören einen automatisch vorgelesenen Beitrag von Philipp Albrecht und Timo Kollbrunner',
+      'Sie hören einen automatisch vorgelesenen Beitrag von Philipp Albrecht und Timo Kollbrunner.',
     )
   })
 
@@ -31,7 +31,7 @@ describe('format credits', () => {
     const input = 'Ein Kommentar von Priscilla Imboden, 23.09.2024'
     const output = addTtsNotice(input)
     expect(output).toEqual(
-      'Sie hören einen automatisch vorgelesenen Beitrag von Priscilla Imboden',
+      'Sie hören einen automatisch vorgelesenen Beitrag von Priscilla Imboden.',
     )
   })
 
@@ -39,7 +39,7 @@ describe('format credits', () => {
     const input = 'von Markus Schärli, 25.09.2024'
     const output = addTtsNotice(input)
     expect(output).toEqual(
-      'Sie hören einen automatisch vorgelesenen Beitrag von Markus Schärli',
+      'Sie hören einen automatisch vorgelesenen Beitrag von Markus Schärli.',
     )
   })
 
@@ -47,7 +47,7 @@ describe('format credits', () => {
     const input = 'Von Markus Schärli 25.09.2024'
     const output = addTtsNotice(input)
     expect(output).toEqual(
-      'Sie hören einen automatisch vorgelesenen Beitrag von Markus Schärli',
+      'Sie hören einen automatisch vorgelesenen Beitrag von Markus Schärli.',
     )
   })
 

--- a/lib/__tests__/formatTitle.test.js
+++ b/lib/__tests__/formatTitle.test.js
@@ -1,0 +1,32 @@
+import { addFullStop } from '../textParser/huebschFormatter.js'
+
+describe('format title', () => {
+  test('should add a full stop at the end', async () => {
+    const input = 'Chronologie der Schweizer Medienkonzentration'
+    const output = addFullStop(input)
+    expect(output).toEqual('Chronologie der Schweizer Medienkonzentration.')
+  })
+
+  test('should not add full stop when the title has punctuation at the end', async () => {
+    const input1 = 'Raus! Raus! Raus!'
+    const output1 = addFullStop(input1)
+    expect(output1).toEqual('Raus! Raus! Raus!')
+
+    const input2 = 'Stell dir vor, es ist Klimastreik und …'
+    const output2 = addFullStop(input2)
+    expect(output2).toEqual('Stell dir vor, es ist Klimastreik und …')
+
+    const input3 = 'Hopfen und Malz verloren?'
+    const output3 = addFullStop(input3)
+    expect(output3).toEqual('Hopfen und Malz verloren?')
+  })
+
+  test('should add a full stop at the end – punctuation present in the middle of the title', async () => {
+    const input =
+      'Das ist rechtlich heikel und nützt wenig – eine Analyse. Zudem: Das Briefing aus Bern'
+    const output = addFullStop(input)
+    expect(output).toEqual(
+      'Das ist rechtlich heikel und nützt wenig – eine Analyse. Zudem: Das Briefing aus Bern.',
+    )
+  })
+})

--- a/lib/__tests__/textParser.test.js
+++ b/lib/__tests__/textParser.test.js
@@ -220,7 +220,7 @@ const simple_huebsch_content = [
     content: [
       {
         type: 'text',
-        text: 'Turbulenter Test Beitrag',
+        text: 'Turbulenter Test Beitrag.',
       },
     ],
   },

--- a/lib/__tests__/textParser.test.js
+++ b/lib/__tests__/textParser.test.js
@@ -1,5 +1,17 @@
 import { getSpeakableText } from '../textParser/index.js'
 
+describe('text processing', () => {
+  test('parser should convert simple mdast into huebsch format', async () => {
+    const speakableText = getSpeakableText(simple_document.content)
+    expect(speakableText).toEqual(simple_huebsch_content)
+  })
+
+  test('parser should convert mdast with list/quote into huebsch format', async () => {
+    const speakableText = getSpeakableText(tricky_document.content)
+    expect(speakableText).toEqual(tricky_huebsch_content)
+  })
+})
+
 const simple_document = {
   id: '123',
   type: 'mdast',
@@ -117,49 +129,6 @@ const simple_document = {
       },
     ],
     meta: {
-      template: 'article',
-      repoId: 'simple-doc',
-      publishDate: '2024-01-20T10:49:28.062Z',
-      lastPublishedAt: '2024-01-20T10:49:28.062Z',
-      description: 'Lead',
-      title: 'Turbulenter Test Beitrag',
-      feed: true,
-      path: '/2024/01/20/simple-doc',
-      credits: {
-        children: [
-          {
-            type: 'text',
-            value: 'Von ',
-          },
-          {
-            children: [
-              {
-                type: 'text',
-                value: 'Tobias Maier',
-              },
-            ],
-            type: 'link',
-            title: null,
-            url: '/~tm',
-          },
-          {
-            type: 'text',
-            value: ', 20.01.2024',
-          },
-        ],
-        type: 'mdast',
-      },
-      creditsString: 'Von Tobias Maier, 20.01.2024',
-      autoSlug: true,
-      contributors: [
-        {
-          kind: 'Text',
-          name: 'Tobias Maier',
-          userId: '123414',
-        },
-      ],
-      slug: 'simple-doc',
-      gallery: true,
       syntheticVoice: 'test voice',
     },
     type: 'root',
@@ -182,7 +151,7 @@ const simple_huebsch_content = [
     content: [
       {
         type: 'text',
-        text: 'Sie hören einen automatisch vorgelesenen Beitrag von Tobias Maier',
+        text: 'Sie hören einen automatisch vorgelesenen Beitrag von Tobias Maier.',
       },
     ],
   },
@@ -283,9 +252,345 @@ const simple_huebsch_content = [
   },
 ]
 
-describe('text processing', () => {
-  test('parser should convert mdast into huebsch format', async () => {
-    const speakableText = getSpeakableText(simple_document.content)
-    expect(speakableText).toEqual(simple_huebsch_content)
-  })
-})
+const tricky_document = {
+  id: '123',
+  type: 'mdast',
+  repoId: 'tricky-doc',
+  content: {
+    children: [
+      {
+        identifier: 'TITLE',
+        data: {},
+        children: [
+          {
+            depth: 1,
+            children: [
+              {
+                type: 'text',
+                value: 'Ich teste den Parser',
+              },
+            ],
+            type: 'heading',
+          },
+          {
+            depth: 2,
+            children: [],
+            type: 'heading',
+          },
+          {
+            children: [
+              {
+                type: 'text',
+                value: 'Ich verwende Listen, Aufzählungen, Zitate, etc.',
+              },
+            ],
+            type: 'paragraph',
+          },
+          {
+            children: [
+              {
+                type: 'text',
+                value: 'Von ',
+              },
+              {
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Anna Traussnig',
+                  },
+                ],
+                type: 'link',
+                title: null,
+                url: '/~7136e370-112f-4353-bf49-ae06b8985f36',
+              },
+              {
+                type: 'text',
+                value: ', 26.09.2024',
+              },
+            ],
+            type: 'paragraph',
+          },
+        ],
+        type: 'zone',
+      },
+      {
+        identifier: 'CENTER',
+        data: {},
+        children: [
+          {
+            children: [
+              {
+                type: 'text',
+                value: 'Ich habe 2 Sache zu sagen:',
+              },
+            ],
+            type: 'paragraph',
+          },
+          {
+            ordered: true,
+            children: [
+              {
+                children: [
+                  {
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'Nur die ergangenen Gedanken haben Wert.',
+                      },
+                    ],
+                    type: 'paragraph',
+                  },
+                ],
+                loose: false,
+                checked: null,
+                type: 'listItem',
+              },
+              {
+                children: [
+                  {
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'Wer ein Warum hat, dem ist kein Wie zu schwer.',
+                      },
+                    ],
+                    type: 'paragraph',
+                  },
+                ],
+                loose: false,
+                checked: null,
+                type: 'listItem',
+              },
+            ],
+            loose: false,
+            start: 1,
+            type: 'list',
+          },
+          {
+            children: [
+              {
+                type: 'text',
+                value: 'Und auch noch ein Zitat. Warte mal.',
+              },
+            ],
+            type: 'paragraph',
+          },
+          {
+            identifier: 'BLOCKQUOTE',
+            data: {},
+            children: [
+              {
+                children: [
+                  {
+                    children: [
+                      {
+                        type: 'text',
+                        value:
+                          'Die Hoffnung ist der Regenbogen über den herabstürzenden jähen Bach des Lebens.',
+                      },
+                    ],
+                    type: 'paragraph',
+                  },
+                  {
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'Und mehr.',
+                      },
+                    ],
+                    type: 'paragraph',
+                  },
+                ],
+                type: 'blockquote',
+              },
+              {
+                children: [
+                  {
+                    type: 'text',
+                    value: 'F. Nietzsche',
+                  },
+                ],
+                type: 'paragraph',
+              },
+            ],
+            type: 'zone',
+          },
+        ],
+        type: 'zone',
+      },
+    ],
+    meta: {
+      syntheticVoice: 'test voice',
+    },
+    type: 'root',
+  },
+}
+
+const tricky_huebsch_content = [
+  {
+    type: 'sound',
+    attrs: {
+      soundName: 'Republik: Jingle',
+    },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Sie hören einen automatisch vorgelesenen Beitrag von Anna Traussnig.',
+      },
+    ],
+  },
+  {
+    type: 'pause',
+    attrs: {
+      pause: 1.5,
+    },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Ich verwende Listen, Aufzählungen, Zitate, etc.',
+      },
+    ],
+  },
+  {
+    type: 'pause',
+    attrs: {
+      pause: 1,
+    },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Ich teste den Parser.',
+      },
+    ],
+  },
+  {
+    type: 'pause',
+    attrs: {
+      pause: 1.5,
+    },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Ich habe 2 Sache zu sagen:',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: '1. Punkt: Nur die ergangenen Gedanken haben Wert.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: '2. Punkt: Wer ein Warum hat, dem ist kein Wie zu schwer.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Und auch noch ein Zitat. Warte mal.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Zitat: Die Hoffnung ist der Regenbogen über den herabstürzenden jähen Bach des Lebens.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Und mehr.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'F. Nietzsche',
+      },
+    ],
+  },
+  {
+    type: 'pause',
+    attrs: {
+      pause: 1.5,
+    },
+  },
+  {
+    type: 'sound',
+    attrs: {
+      soundName: 'Republik: Stinger',
+    },
+  },
+]

--- a/lib/huebsch.js
+++ b/lib/huebsch.js
@@ -66,6 +66,7 @@ export const getFromHuebsch = async (body) => {
     })
     .catch((e) => {
       debug(`failed to fetch ${audioUrl}: ${e.message}`)
+      throw e
     })
 
   debug(audioFile)

--- a/lib/textParser/huebschFormatter.js
+++ b/lib/textParser/huebschFormatter.js
@@ -72,7 +72,7 @@ export const addTtsNotice = (text) => {
       .map((author) => author.replace(/([,]$)/g, ''))
 
     const ttsPreface = 'Sie hören einen automatisch vorgelesenen Beitrag von '
-    return ttsPreface + makeCommaSeparatedString(authors)
+    return ttsPreface + makeCommaSeparatedString(authors) + '.'
   } catch (e) {
     debug('error parsing credits, falling back on original text: %o', e)
     return 'Sie hören einen automatisch vorgelesenen Beitrag. ' + text
@@ -118,7 +118,7 @@ const withPauseAfter = (paragraph, pauseDuration) => [
   pause(pauseDuration),
 ]
 
-const formatParagraph = (voice, text) => ({
+const formatParagraph = (voice, text, preface) => ({
   type: 'paragraph',
   attrs: {
     voiceName: voice,
@@ -127,15 +127,15 @@ const formatParagraph = (voice, text) => ({
   content: [
     {
       type: 'text',
-      text,
+      text: preface ? `${preface} ${text}` : text,
     },
   ],
 })
 
 export const formatForHuebsch = (voice) => (node) => {
-  const { text, caesura } = node
+  const { text, caesura, preface } = node
 
-  const paragraph = formatParagraph(voice, text)
+  const paragraph = formatParagraph(voice, text, preface)
 
   return node.type === 'subtitle'
     ? withPauseAfter(paragraph, 1.2)

--- a/lib/textParser/huebschFormatter.js
+++ b/lib/textParser/huebschFormatter.js
@@ -79,6 +79,12 @@ export const addTtsNotice = (text) => {
   }
 }
 
+// improves the pronunciation of the title
+export const addFullStop = (text) => {
+  const punctuatedEnd = /.*[….?!]$/
+  return text.match(punctuatedEnd) ? text : text + '.'
+}
+
 const formatCredits = (paragraph) => [
   {
     ...paragraph,
@@ -86,6 +92,19 @@ const formatCredits = (paragraph) => [
       {
         type: 'text',
         text: addTtsNotice(paragraph.content[0].text),
+      },
+    ],
+  },
+  pause(1.5),
+]
+
+const formatTitle = (paragraph) => [
+  {
+    ...paragraph,
+    content: [
+      {
+        type: 'text',
+        text: addFullStop(paragraph.content[0].text),
       },
     ],
   },
@@ -121,7 +140,7 @@ export const formatForHuebsch = (voice) => (node) => {
   return node.type === 'subtitle'
     ? withPauseAfter(paragraph, 1.2)
     : node.type === 'title'
-    ? withPauseAfter(paragraph, 1.5)
+    ? formatTitle(paragraph)
     : node.type === 'lead'
     ? withPauseAfter(paragraph, 1)
     : node.type === 'credits'

--- a/lib/textParser/mdastParser.js
+++ b/lib/textParser/mdastParser.js
@@ -122,8 +122,8 @@ const quote = {
     }
 
     return [
-      { type: 'paragraph', text: 'Zitat:' },
-      ...nodes.slice(0, -1),
+      { ...nodes[0], preface: 'Zitat:' },
+      ...nodes.slice(1, -1),
       { ...nodes.slice(-1)[0], caesura: { after: true } },
       // @TODO: Problem, falls 2. Paragraph die Credits-Zeile ist.
       // { type: 'paragraph', text: 'Zitat Ende.' },
@@ -148,13 +148,16 @@ const listItemOrdered = {
 
     return type === 'listItem' && list.match(parent) && parent?.ordered === true
   },
-  tokenize: (node, path) => [
-    {
-      type: 'paragraph',
-      text: `${path.slice(-1).pop().index + 1}. Punkt:`,
-    },
-    ...walk(node, path).flat(),
-  ],
+  tokenize: (node, path) => {
+    const nodes = walk(node, path).flat()
+    return [
+      {
+        ...nodes[0],
+        preface: `${path.slice(-1).pop().index + 1}. Punkt:`,
+      },
+      ...nodes.slice(1, -1),
+    ]
+  },
 }
 
 const listItemParagraph = {


### PR DESCRIPTION
- add full stop at the end of the title
- add full stop at the end of the credits line
- merges "zitat:" or "1. punkt" with first paragraph of the element
- propagate error if get from huebsch fails
