### PR TITLE
Huebsch fixes

### DIFF
--- a/lib/__tests__/formatCredits.test.js
+++ b/lib/__tests__/formatCredits.test.js
@@ -1,4 +1,5 @@
 import { addTtsNotice } from '../textParser/huebschFormatter.js'
+import { getSpeakableText } from '../textParser/index.js'
 
 describe('format credits', () => {
   test('should add notice about synthetic voice and remove date', async () => {
@@ -58,4 +59,103 @@ describe('format credits', () => {
       "Sie hören einen automatisch vorgelesenen Beitrag. C'est Anna qui a écrit ça.",
     )
   })
+
+  test('should add preface even if there is no credit line', async () => {
+    const speakableText = getSpeakableText(newsletterInput)
+    expect(speakableText).toEqual(newsletterOutput)
+  })
 })
+
+const newsletterInput = {
+  children: [
+    {
+      identifier: 'CENTER',
+      data: {},
+      children: [
+        {
+          children: [
+            {
+              type: 'text',
+              value: 'Guten Tag ',
+            },
+          ],
+          type: 'paragraph',
+        },
+        {
+          children: [
+            {
+              type: 'text',
+              value: 'Das haben wir heute für Sie.',
+            },
+          ],
+          type: 'paragraph',
+        },
+      ],
+      type: 'zone',
+    },
+  ],
+  meta: {
+    syntheticVoice: 'test voice',
+  },
+  type: 'root',
+}
+
+const newsletterOutput = [
+  {
+    type: 'sound',
+    attrs: {
+      soundName: 'Republik: Jingle',
+    },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Sie hören einen automatisch vorgelesenen Beitrag.',
+      },
+    ],
+  },
+  {
+    type: 'pause',
+    attrs: {
+      pause: 1.4,
+    },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Guten Tag.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Das haben wir heute für Sie.',
+      },
+    ],
+  },
+  {
+    type: 'sound',
+    attrs: {
+      soundName: 'Republik: Stinger',
+    },
+  },
+]

--- a/lib/__tests__/textParser.test.js
+++ b/lib/__tests__/textParser.test.js
@@ -158,7 +158,7 @@ const simple_huebsch_content = [
   {
     type: 'pause',
     attrs: {
-      pause: 1.5,
+      pause: 1.4,
     },
   },
   {
@@ -170,14 +170,14 @@ const simple_huebsch_content = [
     content: [
       {
         type: 'text',
-        text: 'Lead',
+        text: 'Lead.',
       },
     ],
   },
   {
     type: 'pause',
     attrs: {
-      pause: 1,
+      pause: 1.4,
     },
   },
   {
@@ -196,7 +196,7 @@ const simple_huebsch_content = [
   {
     type: 'pause',
     attrs: {
-      pause: 1.5,
+      pause: 1.4,
     },
   },
   {
@@ -213,6 +213,12 @@ const simple_huebsch_content = [
     ],
   },
   {
+    type: 'pause',
+    attrs: {
+      pause: 1.4,
+    },
+  },
+  {
     type: 'paragraph',
     attrs: {
       voiceName: 'test voice',
@@ -221,14 +227,14 @@ const simple_huebsch_content = [
     content: [
       {
         type: 'text',
-        text: 'Und dann passiert was',
+        text: 'Und dann passiert was.',
       },
     ],
   },
   {
     type: 'pause',
     attrs: {
-      pause: 1.2,
+      pause: 1,
     },
   },
   {
@@ -449,7 +455,7 @@ const tricky_huebsch_content = [
   {
     type: 'pause',
     attrs: {
-      pause: 1.5,
+      pause: 1.4,
     },
   },
   {
@@ -468,7 +474,7 @@ const tricky_huebsch_content = [
   {
     type: 'pause',
     attrs: {
-      pause: 1,
+      pause: 1.4,
     },
   },
   {
@@ -487,7 +493,7 @@ const tricky_huebsch_content = [
   {
     type: 'pause',
     attrs: {
-      pause: 1.5,
+      pause: 1.4,
     },
   },
   {
@@ -577,14 +583,14 @@ const tricky_huebsch_content = [
     content: [
       {
         type: 'text',
-        text: 'F. Nietzsche',
+        text: 'F. Nietzsche.',
       },
     ],
   },
   {
     type: 'pause',
     attrs: {
-      pause: 1.5,
+      pause: 1.4,
     },
   },
   {

--- a/lib/__tests__/textParser.test.js
+++ b/lib/__tests__/textParser.test.js
@@ -421,6 +421,46 @@ const tricky_document = {
             ],
             type: 'zone',
           },
+          {
+            children: [
+              {
+                type: 'text',
+                value: 'Ich habe noch mehr.',
+              },
+            ],
+            type: 'paragraph',
+          },
+          {
+            identifier: 'BLOCKQUOTE',
+            data: {},
+            children: [
+              {
+                children: [
+                  {
+                    children: [
+                      {
+                        type: 'text',
+                        value:
+                          'Die Hoffnung ist der Regenbogen über den herabstürzenden jähen Bach des Lebens.',
+                      },
+                    ],
+                    type: 'paragraph',
+                  },
+                ],
+                type: 'blockquote',
+              },
+            ],
+            type: 'zone',
+          },
+          {
+            children: [
+              {
+                type: 'text',
+                value: 'Und nichts anderes.',
+              },
+            ],
+            type: 'paragraph',
+          },
         ],
         type: 'zone',
       },
@@ -592,6 +632,51 @@ const tricky_huebsch_content = [
     attrs: {
       pause: 1.4,
     },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Ich habe noch mehr.',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Zitat: Die Hoffnung ist der Regenbogen über den herabstürzenden jähen Bach des Lebens.',
+      },
+    ],
+  },
+  {
+    type: 'pause',
+    attrs: {
+      pause: 1.4,
+    },
+  },
+  {
+    type: 'paragraph',
+    attrs: {
+      voiceName: 'test voice',
+      proofreadPromptName: 'Republik Sprechkorrektorat',
+    },
+    content: [
+      {
+        type: 'text',
+        text: 'Und nichts anderes.',
+      },
+    ],
   },
   {
     type: 'sound',

--- a/lib/textParser/huebschFormatter.js
+++ b/lib/textParser/huebschFormatter.js
@@ -1,5 +1,9 @@
 import _debug from 'debug'
 
+// please note: this is sometimes used in a sentence, sometimes as standalone
+// hence the absence of punctuation at the end.
+const TTS_NOTICE = 'Sie hören einen automatisch vorgelesenen Beitrag'
+
 const pause = (duration = 1.4) => ({
   type: 'pause',
   attrs: {
@@ -63,7 +67,7 @@ const makeCommaSeparatedString = (array) => {
 //  (mea culpa – but hey, I wrote tests)
 export const addTtsNotice = (text) => {
   if (!text) {
-    return 'Sie hören einen automatisch vorgelesenen Beitrag.'
+    return `${TTS_NOTICE}.`
   }
   const debug = _debug('speakableText:addTtsNotice')
   try {
@@ -74,11 +78,10 @@ export const addTtsNotice = (text) => {
       .map((author) => author.name)
       .map((author) => author.replace(/([,]$)/g, ''))
 
-    const ttsPreface = 'Sie hören einen automatisch vorgelesenen Beitrag von '
-    return ttsPreface + makeCommaSeparatedString(authors) + '.'
+    return `${TTS_NOTICE} von ${makeCommaSeparatedString(authors)}.`
   } catch (e) {
     debug('error parsing credits, falling back on original text: %o', e)
-    return 'Sie hören einen automatisch vorgelesenen Beitrag. ' + text
+    return `${TTS_NOTICE}. ${text}`
   }
 }
 

--- a/lib/textParser/huebschFormatter.js
+++ b/lib/textParser/huebschFormatter.js
@@ -1,6 +1,6 @@
 import _debug from 'debug'
 
-const pause = (duration = 1) => ({
+const pause = (duration = 1.4) => ({
   type: 'pause',
   attrs: {
     pause: duration,
@@ -62,6 +62,9 @@ const makeCommaSeparatedString = (array) => {
 //  in the backend PROPERLY and store then in the DB PROPERLY
 //  (mea culpa – but hey, I wrote tests)
 export const addTtsNotice = (text) => {
+  if (!text) {
+    return 'Sie hören einen automatisch vorgelesenen Beitrag.'
+  }
   const debug = _debug('speakableText:addTtsNotice')
   try {
     const authorsText = getAuthors(text)
@@ -81,7 +84,8 @@ export const addTtsNotice = (text) => {
 
 // improves the pronunciation of the title
 export const addFullStop = (text) => {
-  const punctuatedEnd = /.*[….?!]$/
+  if (!text) return
+  const punctuatedEnd = /.*[….?!:;]$/
   return text.match(punctuatedEnd) ? text : text + '.'
 }
 
@@ -95,57 +99,56 @@ const formatCredits = (paragraph) => [
       },
     ],
   },
-  pause(1.5),
+  pause(),
 ]
 
-const formatTitle = (paragraph) => [
-  {
-    ...paragraph,
-    content: [
-      {
-        type: 'text',
-        text: addFullStop(paragraph.content[0].text),
-      },
-    ],
-  },
-  pause(1.5),
-]
+export const addAudioFrame = (text) => {
+  return [jingle, ...text, stinger]
+}
 
-export const addAudioFrame = (text) => [jingle, ...text, stinger]
+const withPauseBeforeAfter = (
+  paragraph,
+  pauseDuration1 = 1.4,
+  pauseDuration2 = 1.4,
+) => [pause(pauseDuration1), paragraph, pause(pauseDuration2)]
 
-const withPauseAfter = (paragraph, pauseDuration) => [
+const withPauseAfter = (paragraph, pauseDuration = 1.4) => [
   paragraph,
   pause(pauseDuration),
 ]
 
-const formatParagraph = (voice, text, preface) => ({
-  type: 'paragraph',
-  attrs: {
-    voiceName: voice,
-    proofreadPromptName: 'Republik Sprechkorrektorat',
-  },
-  content: [
-    {
-      type: 'text',
-      text: preface ? `${preface} ${text}` : text,
+const formatParagraph = (voice, text, preface) => {
+  const processedText = addFullStop(text)
+  return {
+    type: 'paragraph',
+    attrs: {
+      voiceName: voice,
+      proofreadPromptName: 'Republik Sprechkorrektorat',
     },
-  ],
-})
+    content: [
+      {
+        type: 'text',
+        text: preface ? `${preface} ${processedText}` : processedText,
+      },
+    ],
+  }
+}
+
+const makePause = (node) => {
+  const { type, caesura } = node
+  return ['lead', 'title'].includes(type) || caesura
+}
 
 export const formatForHuebsch = (voice) => (node) => {
-  const { text, caesura, preface } = node
+  const { text, preface, type } = node
 
   const paragraph = formatParagraph(voice, text, preface)
 
-  return node.type === 'subtitle'
-    ? withPauseAfter(paragraph, 1.2)
-    : node.type === 'title'
-    ? formatTitle(paragraph)
-    : node.type === 'lead'
-    ? withPauseAfter(paragraph, 1)
-    : node.type === 'credits'
+  return type === 'subtitle'
+    ? withPauseBeforeAfter(paragraph, 1.4, 1)
+    : type === 'credits'
     ? formatCredits(paragraph)
-    : caesura
-    ? withPauseAfter(paragraph, 1.5)
+    : makePause(node)
+    ? withPauseAfter(paragraph)
     : paragraph
 }

--- a/lib/textParser/index.js
+++ b/lib/textParser/index.js
@@ -1,10 +1,6 @@
 import _debug from 'debug'
 import { parseMdast } from './mdastParser.js'
-import {
-  addAudioFrame,
-  addTtsNotice,
-  formatForHuebsch,
-} from './huebschFormatter.js'
+import { addAudioFrame, formatForHuebsch } from './huebschFormatter.js'
 
 const removeUnspeakable = (token) => !token.unspeakable
 

--- a/lib/textParser/index.js
+++ b/lib/textParser/index.js
@@ -1,6 +1,10 @@
 import _debug from 'debug'
 import { parseMdast } from './mdastParser.js'
-import { addAudioFrame, formatForHuebsch } from './huebschFormatter.js'
+import {
+  addAudioFrame,
+  addTtsNotice,
+  formatForHuebsch,
+} from './huebschFormatter.js'
 
 const removeUnspeakable = (token) => !token.unspeakable
 
@@ -26,6 +30,18 @@ export function TextParsingError(message, payload) {
 
 TextParsingError.prototype = Error.prototype
 
+// if there is no credits node present (e.g. newsletter)
+// we add one, so that we can attach the tts notice to it.
+const addCreditsNode = (textNodes) => {
+  if (textNodes[0].type === 'credits') return textNodes
+  return [
+    {
+      type: 'credits',
+    },
+    ...textNodes,
+  ]
+}
+
 export const getSpeakableText = (content) => {
   const voice = content.meta.syntheticVoice
   if (!voice) {
@@ -35,10 +51,9 @@ export const getSpeakableText = (content) => {
   debug('begin')
   try {
     const tokens = parseMdast(content)
-    const speakableText = filterTokens(tokens)
-      .map(trimText)
-      .map(formatForHuebsch(voice))
-    const outputText = addAudioFrame(speakableText).flat(1)
+    const cleanText = filterTokens(tokens).map(trimText)
+    const speakableText = addCreditsNode(cleanText).map(formatForHuebsch(voice))
+    const outputText = addAudioFrame(speakableText.flat(1))
 
     debug('done! %o', outputText)
     return outputText

--- a/lib/textParser/mdastParser.js
+++ b/lib/textParser/mdastParser.js
@@ -121,13 +121,12 @@ const quote = {
       return unspeakable(node)
     }
 
-    return [
-      { ...nodes[0], preface: 'Zitat:' },
-      ...nodes.slice(1, -1),
-      { ...nodes.slice(-1)[0], caesura: { after: true } },
-      // @TODO: Problem, falls 2. Paragraph die Credits-Zeile ist.
-      // { type: 'paragraph', text: 'Zitat Ende.' },
-    ]
+    // first node gets a caesura, last node gets a preface
+    return nodes.map((n, idx) => ({
+      ...n,
+      preface: idx === 0 && 'Zitat:',
+      caesura: idx === nodes.length - 1 && { after: true },
+    }))
   },
 }
 


### PR DESCRIPTION
- unify pauses (mostly 1.4 sec pauses, with a couple 1s pauses)
- fix bug: missing tts notice in articles without a credits line. this got fixed by adding an empty credits node to these articles.
- fix bug: duplicate quote when the credits are missing. Fix parsing error.