### PR TITLE
feat(SyntheticVoice): replace all ellispses... with nothing

### DIFF
--- a/lib/__tests__/textParser.test.js
+++ b/lib/__tests__/textParser.test.js
@@ -786,7 +786,7 @@ const embedCommentInput = {
                     {
                       type: 'text',
                       value:
-                        'Das war das beste Artikel des Jahres! (...) Danke dafür',
+                        '(...) Das war das beste Artikel des Jahres! (...) Danke dafür',
                     },
                   ],
                   type: 'paragraph',
@@ -830,7 +830,7 @@ const embedCommentInput = {
               path: '/2024/09/26/ich-teste-den-parser',
               __typename: 'Discussion',
               id: '42f64ae9-27ea-40ff-835b-94d68a4c27c9',
-              title: '(...) Ich teste den Parser',
+              title: 'Ich teste den Parser',
             },
             content: {
               children: [
@@ -847,7 +847,7 @@ const embedCommentInput = {
                   children: [
                     {
                       type: 'text',
-                      value: 'Und dann',
+                      value: 'Und (...) dann',
                     },
                   ],
                   type: 'paragraph',
@@ -1023,7 +1023,7 @@ const embedCommentOutput = [
     content: [
       {
         type: 'text',
-        text: 'Und dann.',
+        text: 'Und  dann.',
       },
     ],
   },

--- a/lib/textParser/index.js
+++ b/lib/textParser/index.js
@@ -8,7 +8,10 @@ const removeTextless = (token) => !!token.text
 
 const trimText = (token) => ({ ...token, text: token.text.trim() })
 
-const removeEllipses = (token) => ({ ...token, text: token.text.replace('(...)', '') })
+const removeEllipses = (token) => ({
+  ...token,
+  text: token.text.replaceAll('(...)', ''),
+})
 
 const filterTokens = (tokens) => {
   const filtered = tokens.filter(removeUnspeakable).filter(removeTextless)


### PR DESCRIPTION
`replace()`is only replacing first occurrence :/
Replaced `replace()`with `replaceAll()`, in order to replace all ellipses with nothing ('') at all 🤷 
(Unit) tested