### PR TITLE
fix(Parsing): skip quote

### DIFF
--- a/lib/__tests__/textParser.test.js
+++ b/lib/__tests__/textParser.test.js
@@ -239,7 +239,7 @@ const simple_huebsch_content = [
   {
     type: 'pause',
     attrs: {
-      pause: 1,
+      pause: 1.4,
     },
   },
   {
@@ -392,6 +392,52 @@ const tricky_document = {
                 type: 'paragraph',
               },
             ],
+          },
+          {
+            identifier: 'QUOTE',
+            data: {},
+            children: [
+              {
+                identifier: 'FIGURE',
+                data: {
+                  excludeFromGallery: false,
+                },
+                children: [
+                  {
+                    children: [
+                      {
+                        alt: null,
+                        type: 'image',
+                        title: null,
+                        url: 'test.com',
+                      },
+                    ],
+                    type: 'paragraph',
+                  },
+                ],
+                type: 'zone',
+              },
+              {
+                children: [
+                  {
+                    type: 'text',
+                    value:
+                      '«Wenn ich als Einzelperson etwas ansprechen möchte, dann muss sich mein Gegenüber damit auseinander­setzen.»',
+                  },
+                ],
+                type: 'paragraph',
+              },
+              {
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Dominik Cavalli',
+                  },
+                ],
+                type: 'paragraph',
+              },
+            ],
+            type: 'zone',
           },
           {
             identifier: 'BLOCKQUOTE',

--- a/lib/textParser/mdastParser.js
+++ b/lib/textParser/mdastParser.js
@@ -112,6 +112,12 @@ const subtitle = {
 
 const quote = {
   match: ({ type, identifier }) => type === 'zone' && identifier === 'QUOTE',
+  tokenize: unspeakable,
+}
+
+const blockQuote = {
+  match: ({ type, identifier }) =>
+    type === 'zone' && identifier === 'BLOCKQUOTE',
   tokenize: (node, path) => {
     const nodes = walk(node, path)
       .flat()
@@ -128,12 +134,6 @@ const quote = {
       caesura: { after: idx === nodes.length - 1 },
     }))
   },
-}
-
-const blockQuote = {
-  match: ({ type, identifier }) =>
-    type === 'zone' && identifier === 'BLOCKQUOTE',
-  tokenize: quote.tokenize,
 }
 
 const list = {


### PR DESCRIPTION
Skip elements like this:

<img width="759" alt="Screenshot 2024-12-17 at 09 51 54" src="https://github.com/user-attachments/assets/3b15dba6-bce2-4c53-af42-c240793adf46" />

> "Zitate wie das von Dominik setzen wir selten ein.
Wenn, dann in der Regel bei Interviews, wenn wir die interviewte Person nicht als Aufmacherbild zeigen.
Diese Foto/Quote-Kombi dient einzig der Optik, es geht also um eine Strukturierung fürs Auge.
Wenn sich diese Zitate, die ja ein eigenes Tool im Werkzeugkasten sind, ohne grossen Aufwand vom Lesen ausschliessen lassen, dann fände ich das sinnvoll, denn ob es die eine oder die andere Stimme liest, macht keinen grossen Unterschied – es ist eh schräg, wenn jemand hört statt liest."

